### PR TITLE
RPM Accuracy Improvement

### DIFF
--- a/ford-fiesta-mk8-petrol/xConnect_link/SHCustomProtocol.h
+++ b/ford-fiesta-mk8-petrol/xConnect_link/SHCustomProtocol.h
@@ -118,8 +118,9 @@ public:
     if(rpm < 0) {
       rpm = 0;
     }
-    rpmgate = 96 + (int)(rpm / 500);  // Calculate the gate and cast to int
-    finetune = (int)(rpm % 500) / 2;
+    int scaledRpm = (int)(rpm * 0.935); // Scale input to display correct RPM on cluster
+    rpmgate = 96 + (int)(scaledRpm / 500);  // Calculate the gate and cast to int
+    finetune = (int)(scaledRpm % 500) / 2;
     if (rpmgate > 115) {
       rpmgate = 115;
     }


### PR DESCRIPTION
Before this commit the RPM on the cluster itself is close to accurate at lower RPM's (e.g. 1800) however it drifts higher than the game input at higher rev ranges (for example the game input at 7000RPM will show 7600RPM on the cluster), this is universal regardless of the game being played.

This commit scales down the RPM by 0.935 which makes the cluster display the correct RPM across the rev range.